### PR TITLE
Replace natural? with exact-nonnegative-integer?

### DIFF
--- a/slideshow/simple/lang/nodes.rkt
+++ b/slideshow/simple/lang/nodes.rkt
@@ -6,7 +6,8 @@
          racket/contract/base)
 
 (provide (contract-out
-          [struct location ((line natural?) (column natural?))]
+          [struct location ((line exact-nonnegative-integer?)
+                            (column exact-nonnegative-integer?))]
           [struct image-slide ((path path-string?)
                                (notes (listof string?))
                                (location location?))]


### PR DESCRIPTION
The natural? alias was only added in 6.8.0.2, so we should preserve compatibility with older versions.